### PR TITLE
use cmake.cmakePath config option to spawn cmake process

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -13,6 +13,11 @@ function strEquals(word, pattern) {
     return word == pattern;
 }
 
+/// configuration helpers
+function config<T>(key: string, defaultValue?: any): T {
+    const cmake_conf = workspace.getConfiguration('cmake');
+    return cmake_conf.get<T>(key, defaultValue);
+}
 
 
 /// Cmake process helpers
@@ -21,7 +26,7 @@ function strEquals(word, pattern) {
 // and return a promise with stdout
 let cmake = (args: string[]): Promise<string> => {
     return new Promise(function(resolve, reject) {
-        let cmd = child_process.spawn('cmake', args.map(arg=> { return arg.replace(/\r/gm, ''); }));
+        let cmd = child_process.spawn(config<string>('cmakePath', 'cmake'), args.map(arg=> { return arg.replace(/\r/gm, ''); }));
         let stdout: string = '';
         cmd.stdout.on('data', function(data) {
             var txt: string = data.toString('utf8');


### PR DESCRIPTION
This is similar to the patch in vscode-cmake-tools, to use the configuration option for selecting the cmake executable binary. This way the completion works great (thanks!) even if cmake is not in the path.

The configuration option is provided by cmake-tools package.
If needed I can also update the package.json so that the option would be "contributed" by this package.

Thanks!