### PR TITLE
Remove deprecated keywords

### DIFF
--- a/syntaxes/CMake.tmLanguage
+++ b/syntaxes/CMake.tmLanguage
@@ -210,7 +210,7 @@
 			<key>comment</key>
 			<string>Derecated keyword</string>
 			<key>match</key>
-			<string>\b(?i:ABSTRACT_FILES|BUILD_NAME|SOURCE_FILES|SOURCE_FILES_REMOVE|VTK_MAKE_INSTANTIATOR|VTK_WRAP_JAVA|VTK_WRAP_PYTHON|VTK_WRAP_TCL|WRAP_EXCLUDE_FILES)\b</string>
+			<string>\bBUILD_NAME\b</string>
 			<key>name</key>
 			<string>invalid.deprecated.source.cmake</string>
 		</dict>


### PR DESCRIPTION
Of all of the names in the list, only BUILD_NAME exists in CMake 3.0.

I like to use the name SOURCE_FILES and don't like that it gets highlighted differently.