### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -1,6 +1,6 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import {workspace, window, languages, ExtensionContext, TextDocument, DocumentFilter, Position, commands, LanguageConfiguration, CompletionItemKind, CompletionItem, SnippetString, CompletionItemProvider, Hover, HoverProvider, Disposable, CancellationToken} from 'vscode';
+import {workspace, window, languages, ExtensionContext, TextDocument, DocumentSelector, Position, commands, LanguageConfiguration, CompletionItemKind, CompletionItem, SnippetString, CompletionItemProvider, Hover, HoverProvider, Disposable, CancellationToken} from 'vscode';
 import util = require('util');
 import child_process = require("child_process");
 
@@ -263,11 +263,16 @@ export function activate(disposables: Disposable[]) {
         });
     });
 
-    const CMAKE_MODE: DocumentFilter = { language: 'cmake', scheme: 'file' }
-    languages.registerHoverProvider('cmake', new CMakeExtraInfoSupport());
-    languages.registerCompletionItemProvider('cmake', new CMakeSuggestionSupport());
+    const CMAKE_LANGUAGE = 'cmake';
+    const CMAKE_SELECTOR: DocumentSelector = [
+        { language: CMAKE_LANGUAGE, scheme: 'file' },
+        { language: CMAKE_LANGUAGE, scheme: 'untitled' },
+    ];
 
-    languages.setLanguageConfiguration(CMAKE_MODE.language, {
+    languages.registerHoverProvider(CMAKE_SELECTOR, new CMakeExtraInfoSupport());
+    languages.registerCompletionItemProvider(CMAKE_SELECTOR, new CMakeSuggestionSupport());
+
+    languages.setLanguageConfiguration(CMAKE_LANGUAGE, {
         indentationRules: {
             // ^(.*\*/)?\s*\}.*$
             decreaseIndentPattern: /^(.*\*\/)?\s*\}.*$/,


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for CMake, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the CMake extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*