### PR TITLE
Fix for upstream issue #49 Hover help truncated to 20 lines

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -354,7 +354,7 @@ class CMakeExtraInfoSupport implements HoverProvider {
             return promises[cmakeTypeFromvscodeKind(suggestion.kind)](suggestion.label).then(function (result: string) {
                 let lines = result.split('\n');
 
-                lines = lines.slice(2, Math.min(20, lines.length));
+                lines = lines.slice(2, Math.max(20, lines.length));
 
 
                 let hover = new Hover({ language: 'md', value: lines.join('\n') });

--- a/extension.ts
+++ b/extension.ts
@@ -353,11 +353,8 @@ class CMakeExtraInfoSupport implements HoverProvider {
 
             return promises[cmakeTypeFromvscodeKind(suggestion.kind)](suggestion.label).then(function (result: string) {
                 let lines = result.split('\n');
-
-                lines = lines.slice(2, Math.max(20, lines.length));
-
-
-                let hover = new Hover({ language: 'md', value: lines.join('\n') });
+                lines = lines.slice(2, lines.length);
+                let hover = new Hover({ language: 'md', value: lines.join('\n') });                
                 return hover;
             });
         });


### PR DESCRIPTION
#49 

Previous behavior:
![before](https://user-images.githubusercontent.com/27447452/58927545-e3eb2180-8703-11e9-9782-c879658b62f4.gif)


Fixed behavior:
![after](https://user-images.githubusercontent.com/27447452/58927567-fb2a0f00-8703-11e9-8fe7-b133d9ff5655.gif)
